### PR TITLE
Interpretation of some dat.specifications fields

### DIFF
--- a/PyPoE/_data/dat.specification.ini
+++ b/PyPoE/_data/dat.specification.ini
@@ -282,14 +282,12 @@
             type = ref|string
             file_path = True
             file_ext = .dds
-        # TODO: Max 16, ActiveSkillTargetType.dat rows -> 15
-        [[[ActiveSkillTargetTypeData]]]
+        # keys to (empty) ActiveSkillTargetTypes.dat with offset 1
+        [[[ActiveSkillTargetTypes]]]
             type = ref|list|uint
-            display = ActiveSkillTargetTypeData?
-        # TODO: Max 58, ActiveSkillType.dat rows -> 57?
-        [[[ActiveSkillTypeData]]]
+        # keys to (empty) ActiveSkillType.dat with offset 1
+        [[[ActiveSkillTypes]]]
             type = ref|list|uint
-            display = ActiveSkillTypeData?
         [[[WeaponRestriction_ItemClassesKeys]]]
             type = ref|list|ulong
             key = ItemClasses.dat
@@ -1185,7 +1183,11 @@ exceed the number of entries; in that case it is player skill."""
             type = int
         [[[Name]]]
             type = ref|string
-        [[[Unknown0]]]
+        # key to (empty) CraftingBenchCustomActions.dat with offset 1
+        # out of range -> no custom action
+        # 1 = "Remove Crafted Mods"
+        # 2 = everything else (out of range)
+        [[[CraftingBenchCustomAction]]]
             type = int
         [[[ItemClassesKeys]]]
             type = ref|list|ulong
@@ -2210,13 +2212,16 @@ exceed the number of entries; in that case it is player skill."""
             type = int
         [[[Cooldown]]]
             type = int
-        # Some kind of movement type?
+        # key to (empty) CooldownBypassTypes.dat with offset 1
+        # out of range -> no bypassing
+        # Whirling Blades has 2 but no cooldown, so doesn't apply
         # 1 = Vigilant Strike
         # 2 = Flicker Strike, Whirling Blades
         # 3 = Cold Snap
-        # 4 = other skills
-        [[[Unknown29]]]
+        # 4 = other skills (out of range)
+        [[[CooldownBypassType]]]
             type = int
+            description = 'Charge type to expend to bypass cooldown (Endurance, Frenzy, Power, none)'
         [[[StatsKeys2]]]
             type = ref|list|ulong
             key = Stats.dat
@@ -2228,10 +2233,17 @@ exceed the number of entries; in that case it is player skill."""
             type = int
         [[[VaalStoredUses]]]
             type = int
-        [[[Unknown32]]]
+        # key to (empty) CooldownGroups.dat with offset 1
+        # out of range -> no shared cooldown
+        # 1 = Warcries
+        # 2-5 = some monster skills
+        # 6 = other skills (out of range)
+        [[[CooldownGroup]]]
             type = int
-        [[[Unknown33]]]
+        # only > 0 for Blasphemy (to 35)
+        [[[ManaReservationOverride]]]
             type = int
+            description = 'Mana Reservation Override: #% (if # > 0)'
         [[[Unknown34]]]
             type = int
         [[[DamageMultiplier]]]
@@ -4657,9 +4669,9 @@ exceed the number of entries; in that case it is player skill."""
         [[[GemTagsKeys]]]
             type = ref|list|ulong
             key = GemTags.dat
-        [[[Key1]]]
+        [[[VaalVariant_BaseItemTypesKey]]]
             type = long
-            #key =
+            key = BaseItemTypes.dat
         [[[Flag0]]]
             type = bool
 [SkillTotemVariations.dat]
@@ -4701,6 +4713,7 @@ exceed the number of entries; in that case it is player skill."""
             type = bool
         [[[IsLocal]]]
             type = bool
+        # true iff MainHandAlias_StatsKey and/or OffHandAlias_StatsKey are not None
         [[[IsWeaponLocal]]]
             type = bool
         [[[Unknown2]]]
@@ -4714,10 +4727,12 @@ exceed the number of entries; in that case it is player skill."""
         [[[Flag6]]]
             type = bool
         # for some reason ints... maybe cause same file?
-        [[[Alias_StatsKey1]]]
+        # value of the stat is added to MainHandAlias_StatsKey if weapon is in main-hand
+        [[[MainHandAlias_StatsKey]]]
             type = int
             key = Stats.dat
-        [[[Alias_StatsKey2]]]
+        # value of the stat is added to OffHandAlias_StatsKey if weapon is in off-hand
+        [[[OffHandAlias_StatsKey]]]
             type = int
             key = Stats.dat
         [[[Flag7]]]


### PR DESCRIPTION
I think I have found out the meaning of a few fields:

- `ActiveSkillTargetTypes`: These define where a skill can be cast, which targets are allowed. I have reverse engineered most of the values, but I'm not sure if knowing what this field does is of any use. (I can add the values if you think they are, types are things like "ground", "enemy", "anywhere", "item")
- `ActiveSkillTargetTypes`: These are basically flags that define what affects the skill and what it can affect (e.g. most gem tags, dual wielding information, supportable by spell totem/mine/trap/spell echo/..., mana cost is reservation, mana cost is percentage). See [`RePoE.constants.ActiveSkillType`](https://github.com/brather1ng/RePoE/blob/master/RePoE/constants.py#L5) for the meanings.
- `CraftingBenchCustomAction`: Some crafting bench options are not mods. This field defines what they do if they aren't (only "Remove Crafted Mods" atm).
- `CooldownBypassType`: If the skill has a cooldown, what can be done to bypass it. These are the three charge types (endurance, frenzy, power). (might be completely wrong if I missed a skill that can be bypassed with charges)
- `CooldownGroup`: Seems to group skills that have a shared cooldown.
- `ManaReservationOverride`: Only greater than 0 for Blasphemy and the value matches its mana reservation override, so it makes sense to be that.
- `VaalVariant_BaseItemTypesKey`: Links to the vaal variant of gems.
- `MainHandAlias_StatsKey` and `OffHandAlias_StatsKey`: Set for stats that either only apply when being in one of the two hands or apply locally to the hand they are in.

I'm not sure whether and where to put the fields that can be defined as enums, so I have only modified `dat.specifications.ini`.
