### PR TITLE
[UI] improve GGPK reading performance

### DIFF
--- a/PyPoE/poe/file/ggpk.py
+++ b/PyPoE/poe/file/ggpk.py
@@ -1032,6 +1032,8 @@ class GGPKFile(AbstractFileReadOnly, metaclass=InheritedDocStringsMeta):
                 ggpkfile=buffer,
                 offset=offset,
             )
+            if callable(kwargs['callback']):
+                kwargs['callback'](records, buffer, offset)
             offset = buffer.tell()
         self.records = records
 


### PR DESCRIPTION
2 changes:
1. Add an optional callback function to GGPK reader that can be used for subscribing to the reading process instead of wrapping (mutating) internal functions.
2. Add a timer to only emit progress bar changes once every 200ms. This is a huge performance impovement.
