### PR TITLE
added missing key information

### DIFF
--- a/PyPoE/_data/dat.specification.ini
+++ b/PyPoE/_data/dat.specification.ini
@@ -488,6 +488,7 @@ exceed the number of entries; in that case it is player skill."""
 [BeyondDemons.dat]
     [[fields]]
         [[[MonsterVarietiesKey]]]
+            key = MonsterVarieties.dat
             type = ulong
         [[[Flag0]]]
             type = bool


### PR DESCRIPTION
This one was obviously missing but there are currently 5 other fields which end in `KeyX` but don't have a key information:
- `Unknown_Keys` in `Chests.dat`
  doesn't follow the usual KeysX pattern
- `MissionKey` in `MissionTileMap.dat`
  whats a Mission?
- `Data0_Keys0` in `NPCShop.dat` 
  is this a Data field or Keys field?
- `ContainsBetaKey` in `ShopPaymentPackage.dat` 
  obvious false positive
- `UniqueItemsKey` in `UniqueJewelLimits.dat`
  what's a UniqueItem?

There might be more in the alpha and beta ini but I only processed the stable client.