### PR TITLE
restore old json exporter format

### DIFF
--- a/PyPoE/cli/exporter/dat/parsers/json.py
+++ b/PyPoE/cli/exporter/dat/parsers/json.py
@@ -94,9 +94,18 @@ class JSONExportHandler(DatExportHandler):
 
             for file_name in args.files:
                 dat_file = dat_files[file_name]
-                header = dict_spec[file_name]['fields']
+                
+                header = [
+                    dict({ 'name': name, 'rowid': index }, **props)
+                    for index, (name, props) 
+                    in enumerate(dict_spec[file_name]['fields'].items())
+                ]
 
-                virtual_header = dict_spec[file_name]['virtual_fields']
+                virtual_header = [
+                    dict({ 'name': name, 'rowid': index }, **props)
+                    for index, (name, props) 
+                    in enumerate(dict_spec[file_name]['virtual_fields'].items())
+                ]
 
                 if args.use_object_format:
                     out_obj = {


### PR DESCRIPTION
b7bc4459c5792fe165336c8331cdfc515f59b0de changed the internal format of the spec which resulted in a changed exported format.

This commit will restore the previously exported format. Additionally it fixes a crash when using --use-object-format.

While the internal change was good for performance there is no reason to change the api. If the change of the api format was intended this PR will at least serve as a bug report for the described crash.