### PR TITLE
Added locale option to export data from language subdirs

### DIFF
--- a/PyPoE/cli/exporter/dat/handler.py
+++ b/PyPoE/cli/exporter/dat/handler.py
@@ -67,6 +67,11 @@ class DatExportHandler(object):
             help='.dat files to export',
             nargs='*',
         )
+        parser.add_argument(
+            '--locale',
+            help='locale code for which data should be exported',
+            dest='locale',
+        )
 
     def handle(self, args):
         ver = config.get_option('version')
@@ -107,7 +112,7 @@ class DatExportHandler(object):
         console(prefix + 'Reading .dat files')
 
         dat_files = {}
-        ggpk_data = ggpk['Data']
+        ggpk_data = self._ggpk_data(args.locale, ggpk)
         remove = []
         for name in tqdm(args.files):
             try:
@@ -126,6 +131,20 @@ class DatExportHandler(object):
             args.files.remove(file_name)
 
         return dat_files
+
+    def _ggpk_data(self, locale, ggpk):
+        ggpk_data = ggpk['Data']
+
+        if locale is None:
+            return ggpk_data
+        elif locale == 'pt':
+            return ggpk_data['Portuguese']
+        elif locale == 'ru':
+            return ggpk_data['Russian']
+        elif locale == 'th':
+            return ggpk_data['Thai']
+        else:
+            raise ValueError('Unrecognized locale ' + str(locale))
 
 
 # =============================================================================


### PR DESCRIPTION
Adds support to export *.dat files in `Data` from subdirectories which represent different languages.

Currently language symbols are dumped as unicode symbols. Adding `enfore_asci=False` to json.dump would convert those to utf8 symbols but I'm not sure if this would break backwards compatibility.

I'm not sure if other distributors contain other languages and if those should be included. Currently the default is not english but rather the base directory. In other distribution this might be e.g. Chinese.