### PR TITLE
Identified fields for inflection identifiers

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -600,7 +600,7 @@ specification = Specification({
             ('UniquePurchase_Costs', Field(
                 type='ref|list|int',
             )),
-            ('Unknown3', Field(
+            ('Inflection', Field(
                 type='ref|string',
             )),
             ('Equip_AchievementItemsKey', Field(
@@ -5924,7 +5924,7 @@ specification = Specification({
             ('Flag0', Field(
                 type='bool',
             )),
-            ('Unknown0', Field(
+            ('Inflection', Field(
                 type='ref|string',
             )),
         )),
@@ -8783,7 +8783,7 @@ specification = Specification({
             ('Text2', Field(
                 type='ref|string',
             )),
-            ('Unknown8', Field(
+            ('Inflection', Field(
                 type='ref|string',
             )),
         )),


### PR DESCRIPTION
These fields contain the inflection identifier used for inflection rules.

Some languages (e.g. German) include inflection rules for certain *.dat files (e.g. Mods#Name). The identifier for those is rules is given in the dat files that determine the "context" (e.g. for magic items the BaseItemType provides the gender which is used in Mods). 

An inflection identifier consists of the gender identifier (`M` for masculine, `N` for neuter, `F` for feminine) and a optional plural identifier (`S` for singular or `P` for plural, default is singular). 

I first named the fields gender but since Words.dat sometimes contains the additional plural identifier I used the more general name Inflection.