### PR TITLE
spec update for BaseItemTypes.dat

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -757,6 +757,13 @@ specification = Specification({
                 type='ref|list|ulong',
                 key='AchievementItems.dat',
             )),
+            # the item which represents this item
+            # in the fragment stash tab since the stash tab
+            # can only hold currencies it seems
+            ('FragmentBaseItemTypesKey', Field(
+                type='uint',
+                key='BaseItemTypes.dat',
+            )),
         )),
         virtual_fields=OrderedDict((
             ('NormalPurchase', VirtualField(


### PR DESCRIPTION
Seems like items are converted when placed in the fragment stash tab.