### PR TITLE
Remove default override

### DIFF
--- a/PyPoE/cli/exporter/dat/__init__.py
+++ b/PyPoE/cli/exporter/dat/__init__.py
@@ -64,7 +64,6 @@ class DatHandler(object):
             'dat',
             help='.dat export',
         )
-        parser.set_defaults(func=lambda args: parser.print_help())
 
         sub = parser.add_subparsers(help='Export type')
         JSONExportHandler(sub)

--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ The docs are occasionally updated until I get a build bot up - however docs can 
 Common problems & advisory
 --------
 * Install **Python 3.4** (on windows 86x (32 bit)) to avoid issues with the UI. Pyside support in other versions is currently not available until pyside2 is released.
-* On windows 10 machines there seems to a be bug in the python install that prevents arguments being passed to the command line interface; you can identify this issue if you get a "help" listing if you supplied more then 1 argument. See [this on stack overflow](https://stackoverflow.com/questions/2640971/windows-is-not-passing-command-line-arguments-to-python-programs-executed-from-t) for possible solutions
-
 
 Overview
 --------


### PR DESCRIPTION
Fixes cli execution under windows 10 falsely identified as failed parameter recognition.

I'm unsure why this default for `func` was overridden. As far as I can tell removing this line does not change current behavior other than allowing the cli usage in windows.

It seems like under windows 10 `DatExportHandler#add_default_arguments` is executed before `cli/exporter/__init__.py` which results in `func` defaulting to the print helper. 