### PR TITLE
Fix plural naming convention for key lists

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -1962,10 +1962,10 @@ specification = Specification({
                 key='AchievementItems.dat',
                 description='Achievement item checked on currency use',
             )),
-            ('Encounter_AchievementItemsKey', Field(
+            ('Encounter_AchievementItemsKeys', Field(
                 type='ref|list|ulong',
                 key='AchievementItems.dat',
-                description='Achievement item granted on encounter',
+                description='Achievement items granted on encounter',
             )),
             ('Key4', Field(
                 type='ulong',
@@ -2670,7 +2670,7 @@ specification = Specification({
             ('SpawnWeight', Field(
                 type='int',
             )),
-            ('ModsKey', Field(
+            ('ModsKeys', Field(
                 type='ref|list|long',
                 key='Mods.dat',
             )),


### PR DESCRIPTION
Just to make sure that `ref|list|*` key fields have plural names.