### PR TITLE
Reintroduced inflection fields

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -752,8 +752,10 @@ specification = Specification({
             ('UniquePurchase_Costs', Field(
                 type='ref|list|int',
             )),
-            ('Unknown3', Field(
+            # see https://github.com/OmegaK2/PyPoE/pull/41 for further explanation
+            ('inflection', Field(
                 type='ref|string',
+                description='the inflection identifier used for i18n in related fields'
             )),
             ('Equip_AchievementItemsKey', Field(
                 type='ulong',
@@ -6652,8 +6654,10 @@ specification = Specification({
             ('Flag0', Field(
                 type='bool',
             )),
-            ('Unknown0', Field(
+            # see https://github.com/OmegaK2/PyPoE/pull/41 for further explanation
+            ('inflection', Field(
                 type='ref|string',
+                description='the inflection identifier used for i18n in related fields'
             )),
         )),
     ),
@@ -9585,8 +9589,10 @@ specification = Specification({
             ('Text2', Field(
                 type='ref|string',
             )),
-            ('Unknown8', Field(
+            # see https://github.com/OmegaK2/PyPoE/pull/41 for further explanation
+            ('inflection', Field(
                 type='ref|string',
+                description='the inflection identifier used for i18n in related fields'
             )),
         )),
     ),


### PR DESCRIPTION
First identified in #41 but removed in a5129f709aa3ffb87320b7ddae7a602e943e626e.

Added some documentation so this doesn't go missing again. Those fields are empty in the top level dat folder because these rules are not required in the English language. Those fields are only required in languages like German.