### PR TITLE
Essences.dat spec overhaul

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -3156,11 +3156,11 @@ specification = Specification({
             ('Unknown11', Field(
                 type='ulong',
             )),
-            ('ModsKey1', Field(
+            ('Display_Wand_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('ModsKey2', Field(
+            ('Display_Bow_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
@@ -3168,35 +3168,35 @@ specification = Specification({
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Amulet1_ModsKey', Field(
+            ('Display_Amulet_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Belt1_ModsKey', Field(
+            ('Display_Ring_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Belt3_ModsKey', Field(
+            ('Display_Belt_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Gloves1_ModsKey', Field(
+            ('Display_Gloves_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Boots1_ModsKey', Field(
+            ('Display_Boots_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('BodyArmour1_ModsKey', Field(
+            ('Display_BodyArmour_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Helmet1_ModsKey', Field(
+            ('Display_Helmet_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Shield1_ModsKey', Field(
+            ('Display_Shield_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
@@ -3223,47 +3223,47 @@ specification = Specification({
             ('Unknown31', Field(
                 type='int',
             )),
-            ('1Hand_ModsKey1', Field(
+            ('Display_Weapon_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('ModsKey13', Field(
+            ('Display_Melee_Weapon_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('ModsKey14', Field(
+            ('Display_1HandWeapon_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('ModsKey15', Field(
+            ('Display_2HandWeapon_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('2Hand_ModsKey1', Field(
+            ('Display_2HandMeleeWeapon_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Boots3_ModsKey', Field(
+            ('Display_Armour_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Ranged_ModsKey', Field(
+            ('Display_Ranged_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Helmet2_ModsKey', Field(
+            ('Helmet_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('BodyArmour2_ModsKey', Field(
+            ('BodyArmour_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Boots2_ModsKey', Field(
+            ('Boots_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Gloves2_ModsKey', Field(
+            ('Gloves_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
@@ -3275,62 +3275,62 @@ specification = Specification({
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('2Hand_ModsKey2', Field(
+            ('Staff_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('2Hand_ModsKey3', Field(
+            ('2HandSword_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('2Hand_ModsKey4', Field(
+            ('2HandAxe_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('2Hand_ModsKey5', Field(
+            ('2HandMace_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('1Hand_ModsKey2', Field(
+            ('Claw_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('1Hand_ModsKey3', Field(
+            ('Dagger_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('1Hand_ModsKey4', Field(
+            ('1HandSword_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('1Hand_ModsKey5', Field(
+            ('1HandThrustingSword_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('1Hand_ModsKey6', Field(
+            ('1HandAxe_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('1Hand_ModsKey7', Field(
+            ('1HandMace_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('1Hand_ModsKey8', Field(
+            ('Sceptre_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('1Hand_ModsKey9', Field(
+            ('Display_Monster_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
             ('ItemLevelRestriction', Field(
                 type='int',
             )),
-            ('Belt2_ModsKey', Field(
+            ('Belt_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Amulet2_ModsKey', Field(
+            ('Amulet_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
@@ -3338,16 +3338,15 @@ specification = Specification({
                 type='ulong',
                 key='Mods.dat',
             )),
-            # Ring? Jewel?
-            ('ModsKey41', Field(
+            ('Display_Jewellry_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('Shield2_ModsKey', Field(
+            ('Shield_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),
-            ('ModsKey43', Field(
+            ('Display_Item_ModsKey', Field(
                 type='ulong',
                 key='Mods.dat',
             )),


### PR DESCRIPTION
Basically all mod keys fall into two groups:
- displayed mods
- applied mods depending on item class

Only quivers have one field for display and application.

The display fields relate to certain groups e.g. `Ranged Weapon` or `One Hand Weapon`. There is some additional squash logic applied e.g. if `Weapon` and `Item` have the same mod key only `Item` is displayed because `Weapon` inherits from `Item`. Additionally if `Weapon` would have a different mod key the `Item` line would be prefixed with `Other`. Don't use the Wiki as a reference here because some essences (e.g. `Contempt`) are not displayed as they are shown ingame. In the case of `Contempt` essences the wiki shows `Shield` and `Other Armour` mods despite them having the same stats and only `Other Armor` shown ingame.

Currently the following lines are squashed:
* `Helmet` into `Armour`
* `Gloves` into `Armour`
* `Boots` into `Armour`
* `Body Armour` into `Armour`
* `Shield` into `Armour`
* `Armour` into `Item`
* `Quiver` into `Item`
* `Jewelry` into `Item`
* `Weapon` into `Item`
* `Bow` into `Weapon`
* `Two Handed Melee Weapon` into `Weapon`
* `One Handed Weapon` into `Weapon`
* `Belt` into `Jewelry`

There might be a single inheritance chain to it but for now this list is sufficient enough to mirror ingame display.

The field names for applied mods regarding 1H and 2H weapons are guessed because there exists currently no essence that applies different mods to maces or axes. I just went with the order in which they appear in `ItemClasses.dat`.

