### PR TITLE
Upgrade pip and setuptools before install test_requirements.txt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 # for PySide/QT4
   - sudo apt-get install -y python3-pyside
 install:
+  - "pip install -U pip setuptools"
   - "pip install -U -r test_requirements.txt"
   - "pip install -U -e ."
 script:

--- a/tests/PyPoE/cli/exporter/wiki/parser/test_wiki_item_parser.py
+++ b/tests/PyPoE/cli/exporter/wiki/parser/test_wiki_item_parser.py
@@ -283,7 +283,7 @@ class TestBaseParser():
 
     # Also test all the skill gems with a projectile mapping
     items += tuple([(v, None) for v in
-                    item.ItemsParser._skill_gem_to_projectile_map.keys()])
+                    item.ItemsParser._SKILL_ID_TO_PROJECTILE_MAP.keys()])
 
     @pytest.mark.parametrize('item_name,cls', items)
     def test_for_errors(self, item_name, cls, item_parser):


### PR DESCRIPTION
Uninstallation of `six` fails with the following problem.

- [race condition replacing a setuptools dependency IOError METADATA no such file](https://github.com/pypa/setuptools/issues/951)

https://travis-ci.org/OmegaK2/PyPoE/builds/361132368#L879
```
  Found existing installation: six 1.10.0
    Uninstalling six-1.10.0:
      Successfully uninstalled six-1.10.0
  Rolling back uninstall of six
Exception:
Traceback (most recent call last):
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2813, in _dep_map
    return self.__dep_map
  File "/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/pkg_resources/__init__.py", line 2624, in __getattr__
    raise AttributeError(attr)
AttributeError: _DistInfoDistribution__dep_map
# (omit)
FileNotFoundError: [Errno 2] No such file or directory: '/home/travis/virtualenv/python3.4.6/lib/python3.4/site-packages/six-1.10.0.dist-info/METADATA'
```

But.. test phase fails. :weary:

```
 ERROR collecting tests/PyPoE/cli/exporter/wiki/parser/test_wiki_item_parser.py 
tests/PyPoE/cli/exporter/wiki/parser/test_wiki_item_parser.py:71: in <module>
    class TestBaseParser():
tests/PyPoE/cli/exporter/wiki/parser/test_wiki_item_parser.py:286: in TestBaseParser
    item.ItemsParser._skill_gem_to_projectile_map.keys()])
E   AttributeError: type object 'ItemsParser' has no attribute '_skill_gem_to_projectile_map'
```

Fix test error on 68df778