### PR TITLE
Added fields for patch 3.2.4c (2)

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -8338,6 +8338,9 @@ specification = Specification({
             ('IsUniqueMap', Field(
                 type='bool',
             )),
+            ('Flag0', Field(
+                type='bool',
+            )),
         )),
     ),
     'StrDexIntMissionUniqueMaps.dat': File(


### PR DESCRIPTION
Field semantics are unknown. Should be complete now.
Previous attempt in 7d73d8145613f2939845c7be0aa4e3798f42b3cb (#59) was incomplete because it was not tested with a full export. This stable spec was successfully used with `pypoe_exporter dat json dummy.json`

