### PR TITLE
fix(spec): adjust field order in CraftingBenchOptions

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -2210,13 +2210,13 @@ specification = Specification({
                 type='ref|list|ulong',
                 key='ItemClasses.dat',
             )),
-            ('Sockets', Field(
+            ('Links', Field(
                 type='int',
             )),
             ('SocketColours', Field(
                 type='ref|string',
             )),
-            ('Links', Field(
+            ('Sockets', Field(
                 type='int',
             )),
             ('ItemQuantity', Field(


### PR DESCRIPTION
The name in rows with sockets or links did not match the fields. Sockets and links were just
switched.