### PR TITLE
Specify ActiveSkillTypes fields in ActiveSkills and GrantedEffects

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -313,8 +313,9 @@ specification = Specification({
                 key='Stats.dat',
                 description='Stat an input stat will be transformed into',
             )),
-            ('Unknown19', Field(
+            ('MinionActiveSkillTypes', Field(
                 type='ref|list|int',
+                description='ActiveSkillTypes of skills of minions summoned by this skill',
             )),
         )),
     ),
@@ -3829,8 +3830,9 @@ specification = Specification({
             ('IsSupport', Field(
                 type='bool',
             )),
-            ('Data0', Field(
+            ('AllowedActiveSkillTypes', Field(
                 type='ref|list|uint',
+                description='This support gem only supports active skills with at least one of these types',
             )),
             # 3.0.0
             ('Multiplier1', Field(
@@ -3847,14 +3849,17 @@ specification = Specification({
             ('Unknown0', Field(
                 type='int',
             )),
-            ('Data1', Field(
+            ('AddedActiveSkillTypes', Field(
                 type='ref|list|uint',
+                description='This support gem adds these types to supported active skills',
             )),
-            ('Data2', Field(
+            ('ExcludedActiveSkillTypes', Field(
                 type='ref|list|uint',
+                description='This support gem does not support active skills with one of these types',
             )),
-            ('Flag0', Field(
+            ('SupportsGemsOnly', Field(
                 type='bool',
+                description='This support gem only supports active skills that come from gem items',
             )),
             ('Unknown1', Field(
                 type='uint',


### PR DESCRIPTION
- `ActiveSkills.Unknown19` (now `MinionActiveSkillTypes`) contains the ActiveSkillTypes of skills of minions summoned by the skill.
- `GrantedEffects.Data0` (now `AllowedActiveSkillTypes`) contains the ActiveSkillTypes of which supported active skills must have at least one for the support gem to be able to support it.
- `GrantedEffects.Data1` (now `AddedActiveSkillTypes`) contains the ActiveSkillTypes added to active skills by the support gem.
- `GrantedEffects.Data2` (now `ExcludedActiveSkillTypes`) contains the ActiveSkillTypes of which supported active skills must have none.
- `GrantedEffects.Flag0` (now `SupportsGemsOnly`) restricts support gems to only apply to active skills from gem items (for Empower, Enlighten and Enhance).

Source: https://github.com/Openarl/PathOfBuilding/blob/master/Export/skills.lua#L199