### PR TITLE
Update PyPoE/poe/file/specification/data/alpha.py

### DIFF
--- a/PyPoE/poe/file/specification/data/alpha.py
+++ b/PyPoE/poe/file/specification/data/alpha.py
@@ -2307,6 +2307,9 @@ specification = Specification({
             ('Unknown0', Field(
                 type='ref|list|int',
             )),
+            ('Unknown1', Field(
+                type='uint',
+            )),
         )),
     ),
     'CurrencyItems.dat': File(


### PR DESCRIPTION
Fix specification error with CraftingBenchOptions seen while generating json files with RePOE on steam installation.