### PR TITLE
Bandaid for CraftingBenchOptions specification size mismatch

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -2318,6 +2318,9 @@ specification = Specification({
             ('Unknown0', Field(
                 type='ref|list|int',
             )),
+            ('Unknown1', Field(
+                type='uint',
+            )),
         )),
     ),
     'CurrencyItems.dat': File(


### PR DESCRIPTION
Seen on my current delve installation.