### PR TITLE
Reintroduce language as cli flag to pypoe_exporter

### DIFF
--- a/PyPoE/cli/exporter/dat/handler.py
+++ b/PyPoE/cli/exporter/dat/handler.py
@@ -68,6 +68,13 @@ class DatExportHandler(object):
             nargs='*',
         )
 
+        parser.add_argument(
+            '-lang', '--language',
+            help='Language subdirectory to use',
+            dest='language',
+            default=None,
+        )
+
     def handle(self, args):
         ver = config.get_option('version')
 
@@ -108,7 +115,7 @@ class DatExportHandler(object):
 
         dat_files = {}
         ggpk_data = ggpk['Data']
-        lang = config.get_option('language')
+        lang = args.language or config.get_option('language')
         if lang != 'English':
             ggpk_data = ggpk_data[lang]
         remove = []


### PR DESCRIPTION
Originally added in 4455287658d7e9b3bea1765cfb3242eca66170ec and moved from cli option to config option in b423388b9b907b056de017a241040c0a3ec35f61 without rationale.

I currently run something similar to `pypoe_exporter dat json --files $files --language $language`. Looks like it's currently arbitrary what's a cli and config option. Since it was originally proposed (#40) as a cli flag and implemented as such I would like to keep this behavior.