### PR TITLE
Update unknown field name

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -3282,11 +3282,11 @@ specification = Specification({
                 type='ref|list|ulong',
                 key='Mods.dat',
             )),
-            ('Unknown_TagsKeys', Field(
+            ('NegativeWeight_TagsKeys', Field(
                 type='ref|list|ulong',
                 key='Tags.dat',
             )),
-            ('Unknown_Values', Field(
+            ('NegativeWeight_Values', Field(
                 type='ref|list|int',
             )),
             ('Mods_Keys1', Field(


### PR DESCRIPTION
Not sure about the naming, but the Unknown Tag/Values in DelveCraftingModifiers actually refers to the tags a fossil block (i.e "no X modifiers"), or make less common (i.e "Fewer X modifiers"), so NegativeWeights seems an OK prefix :)
