### PR TITLE
Fixed a DeprecationWarning for collections.Iterable removed in Python 3.8

### DIFF
--- a/PyPoE/poe/file/dat.py
+++ b/PyPoE/poe/file/dat.py
@@ -500,7 +500,7 @@ class DatReader(ReprMixin):
         'double': ['d', 8],
     }
 
-    def __init__(self, file_name, *_args, use_dat_value=True, specification=None,
+    def __init__(self, file_name, *args, use_dat_value=True, specification=None,
                  auto_build_index=False):
         """
         Parameters

--- a/PyPoE/poe/file/dat.py
+++ b/PyPoE/poe/file/dat.py
@@ -72,7 +72,8 @@ Internal API
 import struct
 import warnings
 from io import BytesIO
-from collections import OrderedDict, Iterable, defaultdict
+from collections import OrderedDict, defaultdict
+from collections.abc import Iterable
 
 # 3rd-party
 
@@ -157,7 +158,7 @@ class DatValue(object):
         self.child = None
 
     def __repr__(self):
-        #TODO: iterative vs recursive?
+        # TODO: iterative vs recursive?
         if self.is_pointer:
             return repr(self.child)
         elif self.is_list:
@@ -499,7 +500,7 @@ class DatReader(ReprMixin):
         'double': ['d', 8],
     }
 
-    def __init__(self, file_name, *args, use_dat_value=True, specification=None,
+    def __init__(self, file_name, *_args, use_dat_value=True, specification=None,
                  auto_build_index=False):
         """
         Parameters
@@ -733,8 +734,8 @@ class DatReader(ReprMixin):
                         value.append(self._cast_from_spec(specification, casts[1:], value, data_offset+i*casts[1:][0][1]))
                 elif casts[0][0] == 4:
                     value = self._cast_from_spec(specification, casts[1:], None, data_offset)
-        # TODO
-        #if parent:
+        # TODO:
+        # if parent:
         #    self._data_offset_current = offset
         #    self.data_parsed.append(value)
 
@@ -794,7 +795,7 @@ class DatReader(ReprMixin):
         elif self.table_rows == 0 and self.table_length == 0:
             self.table_record_length = 0
         else:
-            #TODO
+            # TODO
             raise ValueError("WTF")
 
         if self.specification is None:
@@ -897,7 +898,7 @@ class DatFile(AbstractFileReadOnly):
     reader : DatReader
         reference to the DatReader instance once :meth:`read` has been called
     """
-    
+
     def __init__(self, file_name):
         """
         Parameters
@@ -1131,5 +1132,5 @@ def set_default_spec(version=constants.VERSION.DEFAULT, reload=False):
 # Init
 # =============================================================================
 
-set_default_spec()
 
+set_default_spec()

--- a/PyPoE/ui/shared/file/manager.py
+++ b/PyPoE/ui/shared/file/manager.py
@@ -41,12 +41,13 @@ from PyPoE.ui.shared.file.handler import *
 
 __all__ = ['FileDataManager']
 
-#EXTENSION_ANY = 1
-#FILE_ANY = 1
+# EXTENSION_ANY = 1
+# FILE_ANY = 1
 
 # =============================================================================
 # Classes
 # =============================================================================
+
 
 class FileDataManager(object):
     # Settings
@@ -86,7 +87,7 @@ class FileDataManager(object):
         ('.ast', None),
         ('.atlas', TEXT_DATA_HANDLER_UTF16_LE),  # GGG Format? Decals on materials
         ('.bat', TEXT_DATA_HANDLER_UTF8),  # Windows Batch File/Script
-        ('.cfg', TEXT_DATA_HANDLER_UTF8), # Config File
+        ('.cfg', TEXT_DATA_HANDLER_UTF8),  # Config File
         ('.cht', TEXT_DATA_HANDLER_UTF16_LE),  # GGG Format? Terrain.
         ('.clt', TEXT_DATA_HANDLER_UTF16_LE),  # GGG Format? Terrain.
         ('.dat', DAT_DATA_HANDLER),  # TODO
@@ -118,10 +119,10 @@ class FileDataManager(object):
         # GGG Format. Some compiled stuff or binary data
         # Only one at: Metadata/Effects/Spells/rampage/shockwave/rig.mb
         ('.mb', None),
-        ('.mel', TEXT_DATA_HANDLER_UTF8), # Maya Embeeded Language
+        ('.mel', TEXT_DATA_HANDLER_UTF8),  # Maya Embeeded Language
         ('.mtd', TEXT_DATA_HANDLER_UTF16_LE),  # GGG Format? Terrain.
-        ('.mtp', TEXT_DATA_HANDLER_UTF16_LE),  # GGG Format? MiniMap stuff TODO semi-broken display
-        ('.ogg', None), # TODO OGG Music Format
+        ('.mtp', TEXT_DATA_HANDLER_UTF16_LE),  # GGG Format? MiniMap stuff TODO: semi-broken display
+        ('.ogg', None),  # TODO: OGG Music Format
         ('.ot', TEXT_DATA_HANDLER_UTF16_LE),  # GGG Format? Metadata
         ('.otc', TEXT_DATA_HANDLER_UTF16_LE),  # GGG Format? Metadata Client
         ('.pet', TEXT_DATA_HANDLER_UTF16_LE),  # GGG Format?
@@ -151,7 +152,7 @@ class FileDataManager(object):
         ('.sm', TEXT_DATA_HANDLER_UTF16_LE),
         # GGG Format? Probably the compiled skinned mash
         ('.smd', TEXT_DATA_HANDLER_UTF16_LE),
-        ('.tdt', None),  # GGG Format? # TODO ASCII?
+        ('.tdt', None),  # GGG Format? # TODO: ASCII?
         # GGG Format? Mesh for tiles
         # Accompanied by a corresponding .tgt file
         ('.tgm', None),
@@ -182,6 +183,7 @@ class FileDataManager(object):
         ('.xls', None),  # Microsoft Excel
         ('.xml', None),  # XML Files
     ]
+
     def __init__(self, parent, load_default=True):
         self._parent = parent
         self.handlers = {
@@ -246,7 +248,7 @@ class FileDataManager(object):
         else:
             raise TypeError('extension must be a string or EXTENSION_ANY')
 
-        if (isinstance(filenames, collections.Iterable) or
+        if (isinstance(filenames, collections.abc.Iterable) or
                 isinstance(filenames, int) and
                 filenames == FileDataManager.FILE_ANY):
             pass


### PR DESCRIPTION
From https://docs.python.org/3/library/collections.html:
Changed in version 3.3: Moved Collections Abstract Base Classes to the collections.abc module. For backwards compatibility, they continue to be visible in this module through Python 3.7. Subsequently, they will be removed entirely.