### PR TITLE
Updated Shrines Unknown0 variable name

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -15559,8 +15559,8 @@ specification = Specification({
                 type='ref|string',
                 unique=True,
             )),
-            ('Unknown0', Field(
-                name='Unknown0',
+            ('TimeoutInSeconds', Field(
+                name='TimeoutInSeconds',
                 type='int',
             )),
             ('Name', Field(


### PR DESCRIPTION
Timeout is basically time it takes for the Shrine buff to come back up.
Tested it with PVPArea Shrine, the value is accurate.
0 means buff is not going come back up again.