### PR TITLE
CLI output optionally target a folder

### DIFF
--- a/PyPoE/cli/exporter/dat/handler.py
+++ b/PyPoE/cli/exporter/dat/handler.py
@@ -127,10 +127,14 @@ class DatExportHandler:
                 remove.append(name)
                 continue
 
-            df = dat.DatFile(name)
-            df.read(file_path_or_raw=node.record.extract(), use_dat_value=False)
+            try:
+                df = dat.DatFile(name)
+                df.read(file_path_or_raw=node.record.extract(), use_dat_value=False)
 
-            dat_files[name] = df
+                dat_files[name] = df
+            except:
+                print('Error occured for %s' % name)
+                remove.append(name)
 
         for file_name in remove:
             args.files.remove(file_name)


### PR DESCRIPTION
Allows the user to provide a folder for 'target' using the CLI dat to json exporter, and it will create a separate file for each of the dat files in that folder.

That is, now you can run 

```
pypoe_exporter dat json <folder>
```

And it will export all of the dat files as json to the specified folder.

I'm not sure what the error is exactly, but on:

```
AlternateSkillTargetingBehaviours.dat
AtlasExiles.dat
MapSeries.dat
```

I got the following error:

```
PyPoE.poe.file.specification.errors.SpecificationError: <ERRORS.RUNTIME_ROWSIZE_MISMATCH: 3002>: "AlternateSkillTargetingBehaviours.dat": Specification row size 16 vs real size 32
```

Since I didn't know what the problem was, I just excepted all errors. Let me know if this should change.