### PR TITLE
Change QuestRewards -> Quest to have QuestRewardOffers in between

### DIFF
--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -15588,9 +15588,10 @@ specification = Specification({
                 name='Id',
                 type='ref|string',
             )),
-            ('Unknown1', Field(
-                name='Unknown1',
+            ('QuestKey', Field(
+                name='QuestKey',
                 type='ulong',
+                key='Quest.dat',
             )),
             ('QuestState', Field(
                 name='QuestState',
@@ -15614,10 +15615,10 @@ specification = Specification({
     ),
     'QuestRewards.dat': File(
         fields=OrderedDict((
-            ('QuestKey', Field(
-                name='QuestKey',
+            ('QuestRewardOffersKey', Field(
+                name='QuestRewardOffersKey',
                 type='ulong',
-                key='Quest.dat',
+                key='QuestRewardOffers.dat',
             )),
             ('Unknown1', Field(
                 name='Unknown1',


### PR DESCRIPTION
Seems like they change the way QuestRewards references Quest in 3.9.0 and added QuestRewardOffers as a step in between. This broke everything that relied upon that reference, e.g. brather1ng/RePoE#21