### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/PyPoE/cli/exporter/wiki/admin/unique.py
+++ b/PyPoE/cli/exporter/wiki/admin/unique.py
@@ -42,7 +42,7 @@ from collections import defaultdict
 # 3rd-party
 import mwclient
 import mwparserfromhell
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 # self
 from PyPoE.poe.constants import WORDLISTS

--- a/README.md
+++ b/README.md
@@ -73,4 +73,4 @@ Credits - Libraries
 * graphviz ([pypi](https://pypi.org/project/graphviz/))
 * mwclient ([pypi](https://pypi.org/project/mwclient/))
 * mwclientparserfromhell ([pypi](https://pypi.org/project/mwparserfromhell/))
-* fuzzywuzzy ([pypi](https://pypi.org/project/fuzzywuzzy/))
+* rapidfuzz ([pypi](https://pypi.org/project/rapidfuzz/))

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ here = path.abspath(path.dirname(__file__))
 
 extras_require = {
     'dev': ['sphinx', 'pytest'],
-    'cli': ['colorama', 'graphviz', 'tqdm', 'mwclient', 'mwparserfromhell', 'fuzzywuzzy'],
+    'cli': ['colorama', 'graphviz', 'tqdm', 'mwclient', 'mwparserfromhell', 'rapidfuzz'],
     'ui': ['pyside2==5.14.0'],
     'ui-extra': ['PyOpenGL'],
 }

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ graphviz
 tqdm
 mwclient
 mwparserfromhell
-fuzzywuzzy
+rapidfuzz
 sqlalchemy
 pymysql
 PyOpenGL


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2. I had the same problem on one of my projects and so I wrote [rapidfuzz](https://github.com/rhasspy/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed and is therefore MIT Licensed aswell, so it can be used in here without forcing a License change. As a nice bonus it is fully implemented in C++ and comes with a few Algorithmic improvements making it between 5 and 100 times faster than FuzzyWuzzy.