### PR TITLE
Rename 3 spec fields of CurrencyItems.dat

### DIFF
--- a/PyPoE/poe/file/specification/data/alpha.py
+++ b/PyPoE/poe/file/specification/data/alpha.py
@@ -5465,8 +5465,8 @@ specification = Specification({
                 name='Action',
                 type='ref|string',
             )),
-            ('Directions', Field(
-                name='Directions',
+            ('Description', Field(
+                name='Description',
                 type='ref|string',
             )),
             ('FullStack_BaseItemTypesKey', Field(
@@ -5475,8 +5475,8 @@ specification = Specification({
                 key='BaseItemTypes.dat',
                 description='Full stack transforms into this item',
             )),
-            ('Description', Field(
-                name='Description',
+            ('Usage', Field(
+                name='Usage',
                 type='ref|string',
             )),
             ('Usage_AchievementItemsKeys', Field(
@@ -5513,8 +5513,8 @@ specification = Specification({
                 name='Abbreviation',
                 type='ref|string',
             )),
-            ('XBoxDirections', Field(
-                name='XBoxDirections',
+            ('XBoxDescription', Field(
+                name='XBoxDescription',
                 type='ref|string',
             )),
             ('Unknown1', Field(

--- a/PyPoE/poe/file/specification/data/beta.py
+++ b/PyPoE/poe/file/specification/data/beta.py
@@ -2126,8 +2126,8 @@ specification = Specification({
                 name='Action',
                 type='ref|string',
             )),
-            ('Directions', Field(
-                name='Directions',
+            ('Description', Field(
+                name='Description',
                 type='ref|string',
             )),
             ('FullStack_BaseItemTypesKey', Field(
@@ -2136,8 +2136,8 @@ specification = Specification({
                 key='BaseItemTypes.dat',
                 description='Full stack transforms into this item',
             )),
-            ('Description', Field(
-                name='Description',
+            ('Usage', Field(
+                name='Usage',
                 type='ref|string',
             )),
             ('Usage_AchievementItemsKeys', Field(
@@ -2174,8 +2174,8 @@ specification = Specification({
                 name='Abbreviation',
                 type='ref|string',
             )),
-            ('XBoxDirections', Field(
-                name='XBoxDirections',
+            ('XBoxDescription', Field(
+                name='XBoxDescription',
                 type='ref|string',
             )),
         )),

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -5473,8 +5473,8 @@ specification = Specification({
                 name='Action',
                 type='ref|string',
             )),
-            ('Directions', Field(
-                name='Directions',
+            ('Description', Field(
+                name='Description',
                 type='ref|string',
             )),
             ('FullStack_BaseItemTypesKey', Field(
@@ -5483,8 +5483,8 @@ specification = Specification({
                 key='BaseItemTypes.dat',
                 description='Full stack transforms into this item',
             )),
-            ('Description', Field(
-                name='Description',
+            ('Usage', Field(
+                name='Usage',
                 type='ref|string',
             )),
             ('Usage_AchievementItemsKeys', Field(
@@ -5521,8 +5521,8 @@ specification = Specification({
                 name='Abbreviation',
                 type='ref|string',
             )),
-            ('XBoxDirections', Field(
-                name='XBoxDirections',
+            ('XBoxDescription', Field(
+                name='XBoxDescription',
                 type='ref|string',
             )),
             ('Unknown1', Field(


### PR DESCRIPTION
Renamed three fields of `CurrencyItems.dat`:

```
Directions -> Description
Description -> Usage
XBoxDirections -> XBoxDescription
```

I think it is more approched to the scenario, here's some sample (unimportant fields removed):

[![image](https://user-images.githubusercontent.com/11359892/89173163-67c5c580-d5b6-11ea-88e1-8280dad2e6d0.png)](https://pathofexile.gamepedia.com/Winged_Metamorph_Scarab)

### CurrencyItems.json
```json
{
  "BaseItemTypesKey": 6617,
  "Stacks": 1,
  "CurrencyUseType": 3,
  "Directions": "Can be used in a personal Map Device to add modifiers to a Map.",
  "Description": "Area contains Metamorph Monsters\r\nMetamorph Bosses which drop an Itemised Sample drop two additional Itemised Samples\r\nAll Metamorph Monsters have Rewards",
  "XBoxDirections": "Can be used in a personal Map Device to add modifiers to a Map."
}
```

[![image](https://user-images.githubusercontent.com/11359892/89173212-7b712c00-d5b6-11ea-9e88-fea11a9142b2.png)](https://pathofexile.gamepedia.com/Black_Oil)

### CurrencyItems.json
```json
{
  "BaseItemTypesKey": 6618,
  "Stacks": 10,
  "CurrencyUseType": 3,
  "Directions": "Can be combined with other Oils at Cassia to Enchant Rings or Amulets, or to modify Blighted Maps.",
  "Description": "",
  "XBoxDirections": ""
}
```