### PR TITLE
Partial specification update for 3.13

### DIFF
--- a/PyPoE/poe/constants.py
+++ b/PyPoE/poe/constants.py
@@ -678,6 +678,8 @@ class MOD_DOMAIN(IntEnumOverride):
         TODO
     HEIST_TRINKET
         TODO
+    UNKNOWN4
+        TODO
     UNDEFINED
         TODO
     """
@@ -706,7 +708,8 @@ class MOD_DOMAIN(IntEnumOverride):
     HEIST_AREA = 22
     HEIST_NPC = 23
     HEIST_TRINKET = 24
-    UNDEFINED = 25
+    UNKNOWN4 = 25
+    UNDEFINED = 26
 
     # legacy names
     MASTER = CRAFTED

--- a/PyPoE/poe/file/specification/data/stable.py
+++ b/PyPoE/poe/file/specification/data/stable.py
@@ -457,6 +457,15 @@ specification = Specification({
                 file_path=True,
                 file_ext='.ai',
             ),
+            # TODO 3.13
+            Field(
+                name='Unknown2',
+                type='int',
+            ),
+            Field(
+                name='Unknown3',
+                type='int',
+            ),
         ),
     ),
     'AddBuffToTargetVarieties.dat': File(
@@ -11645,6 +11654,15 @@ specification = Specification({
                 name='Flag4',
                 type='bool',
             ),
+            # TODO 3.13
+            Field(
+                name='Unknown3',
+                type='int',
+            ),
+            Field(
+                name='Flag5',
+                type='bool',
+            ),
         ),
     ),
     'ItemCostPerLevel.dat': File(
@@ -15070,6 +15088,11 @@ specification = Specification({
                 name='Heist_AddStatValue2',
                 type='int',
             ),
+            # TODO 3.13
+            Field(
+                name='Unknown4',
+                type='int',
+            ),
         ),
         virtual_fields=(
             VirtualField(
@@ -16482,6 +16505,11 @@ specification = Specification({
                 name='Key3',
                 type='ulong',
             ),
+            # TODO 3.13
+            Field(
+                name='Flag6',
+                type='byte',
+            ),
         ),
     ),
     'MoveDaemon.dat': File(
@@ -17049,6 +17077,15 @@ specification = Specification({
                 name='Unknown1',
                 type='int',
             ),
+            # TODO 3.13
+            Field(
+                name='Unknown2',
+                type='int',
+            ),
+            Field(
+                name='Unknown3',
+                type='int',
+            ),
         ),
     ),
     'NPCShop.dat': File(
@@ -17094,6 +17131,11 @@ specification = Specification({
             ),
             Field(
                 name='Unknown2',
+                type='int',
+            ),
+            # TODO 3.13
+            Field(
+                name='Unknown3',
                 type='int',
             ),
         ),
@@ -17369,6 +17411,15 @@ specification = Specification({
                 name='PortraitFile',
                 type='ref|string',
                 file_path=True,
+            ),
+            # TODO 3.13
+            Field(
+                name='Unknown4',
+                type='int',
+            ),
+            Field(
+                name='Unknown5',
+                type='int',
             ),
         ),
     ),
@@ -17952,6 +18003,11 @@ specification = Specification({
                 name='IsProxyPassive',
                 type='byte',
             ),
+            # TODO 3.13
+            Field(
+                name='Unknown1',
+                type='int',
+            ),
         ),
         virtual_fields=(
             VirtualField(
@@ -18411,6 +18467,15 @@ specification = Specification({
             ),
             Field(
                 name='Unknown13',
+                type='int',
+            ),
+            # TODO 3.13
+            Field(
+                name='Unknown14',
+                type='int',
+            ),
+            Field(
+                name='Unknown15',
                 type='int',
             ),
         ),
@@ -18941,6 +19006,11 @@ specification = Specification({
             ),
             Field(
                 name='Rank',
+                type='int',
+            ),
+            # TODO 3.13
+            Field(
+                name='Unknown0',
                 type='int',
             ),
         ),
@@ -20146,6 +20216,15 @@ specification = Specification({
             Field(
                 name='Flag10',
                 type='bool',
+            ),
+            # TODO 3.13
+            Field(
+                name='Unknown2',
+                type='int',
+            ),
+            Field(
+                name='Unknown3',
+                type='int',
             ),
         ),
     ),

--- a/PyPoE/poe/sim/formula.py
+++ b/PyPoE/poe/sim/formula.py
@@ -194,6 +194,8 @@ def gem_stat_requirement(level, gtype=GemTypes.support, multi=100):
             a = 2.1
             # can't find a good a for 8
             b = 7.75
+        elif multi == 75:
+            a = 1.6
         elif multi == 60:
             a = 1.325
         elif multi == 40:


### PR DESCRIPTION
I didn't look into any of the added fields, only fixed the lengths, so the data types are probably completely incorrect.

This includes only the dat files that are used (or referenced by used files) in RePoE.

The added multi in formula.py was flying around in my local clone since 3.11 or 3.12. Figured I might as well include it here.